### PR TITLE
Add cairosvg to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    install_requires=["requests"],
+    install_requires=["requests", "cairosvg"],
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
cairosvg is missing from install_requires, even though it is unconditionally imported.